### PR TITLE
feat(ui): Invert color of timetable in dark mode

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -7,3 +7,7 @@
 * {
     font-family: "Raleway", sans-serif;
 }
+
+[data-theme="dark"] img {
+    filter: invert(1);
+}


### PR DESCRIPTION
I used this css trick for a while on my browser for VT-next to avoid a too luminous timetable image, and thought It could interest you.

It simply inverts the color of the image when the dark mode is on.

